### PR TITLE
PLAT-6932-Update-EKS-and-IonCube

### DIFF
--- a/nginx-configmap/nginx-configmap.yaml
+++ b/nginx-configmap/nginx-configmap.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: ingress-nginx-controller
 data:
+  allow-snippet-annotations: "true"
+  annotations-risk-level: "Critical"
   http-snippet: |
       log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
update chart to be compatible with V1.12, as ingress snippetes were moved from "high" to "critical"